### PR TITLE
image() for txtplot

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,3 @@
 importFrom("grDevices", "boxplot.stats")
-importFrom("stats", "acf", "density", "na.fail", "fft")
+importFrom("stats", "acf", "density", "na.fail")
 export(txtplot, txtdensity, txtcurve, txtacf, txtbarchart, txtboxplot, txtimage)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,3 @@
 importFrom("grDevices", "boxplot.stats")
-importFrom("stats", "acf", "density", "na.fail")
-export(txtplot, txtdensity, txtcurve, txtacf, txtbarchart, txtboxplot)
+importFrom("stats", "acf", "density", "na.fail", "loess", "predict")
+export(txtplot, txtdensity, txtcurve, txtacf, txtbarchart, txtboxplot, txtimage)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,3 @@
 importFrom("grDevices", "boxplot.stats")
-importFrom("stats", "acf", "density", "na.fail", "loess", "predict")
+importFrom("stats", "acf", "density", "na.fail", "fft")
 export(txtplot, txtdensity, txtcurve, txtacf, txtbarchart, txtboxplot, txtimage)

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -3,21 +3,24 @@ txtimage <- function(
   z, width, height, yaxis = c('up', 'down'), image.transpose = T, na.char = ' ',
   alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 ) {
-  if (image.transpose) z <- t(z)
-  if (missing(width)) width <- min(getOption('width'), ncol(z))
-  if (missing(height)) height <- min(getOption('width') * 25 / 80, ncol(z))
-  if (width != ncol(z) || height != nrow(z)) { # must resample z to specified size
-    z <- Mod(fft(fft(z)[1:height, 1:width], inverse = T))
-  }
-  if (match.arg(yaxis) == 'up') z <- z[height:1,]
+  stopifnot(!is.infinite(z)) # check for +/- Inf before performing any computations involving range()
 
   # alphabet could be either a multi-character string or a vector of characters
   if (length(alphabet) == 1) alphabet <- strsplit(alphabet, NULL)[[1]]
   stopifnot(nchar(alphabet) == 1)
 
+  if (image.transpose) z <- t(z)
+  if (missing(width)) width <- min(getOption('width'), ncol(z))
+  if (missing(height)) height <- min(getOption('width') * 25 / 80, nrow(z))
+
+  if (width != ncol(z) || height != nrow(z)) { # must resample z to specified size
+    z <- Mod(fft(fft(z)[1:height, 1:width], inverse = T))
+  }
+
+  if (match.arg(yaxis) == 'up') z <- z[height:1,]
+
   indices <- (z - min(z, na.rm = T))/diff(range(z, na.rm = T)) # \in [0;1]
   indices <- 1 + indices * (length(alphabet) - 1) # \in [1; length(alphabet)]
-  indices[!is.finite(indices)] <- NA # in case we got NaNs
 
   if (na.char %in% alphabet && any(is.na(indices)))
     warning("NAs indistinguishable from values in the plot")

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -2,23 +2,13 @@
 txtimage <- function(
   x, width, height,
   alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  yaxis = c('up', 'down'), image.transpose = T, span = .1, ...
+  yaxis = c('up', 'down'), image.transpose = T
 ) {
   if (image.transpose) x <- t(x)
   if (missing(width)) width <- min(getOption('width'), ncol(x))
   if (missing(height)) height <- min(width * .25, ncol(x))
   if (width != ncol(x) || height != nrow(x)) { # must resample x to specified size
-    df <- data.frame(
-      x = as.vector(x),
-      # i, j \in [0; 1]
-      i = as.vector(row(x) - 1)/(nrow(x) - 1),
-      j = as.vector(col(x) - 1)/(ncol(x) - 1)
-    )
-    newdf <- expand.grid(
-      i = seq(0, 1, length = height),
-      j = seq(0, 1, length = width)
-    )
-    x <- predict(loess(x ~ i * j, df, span = span, ...), newdf)
+    x <- Mod(fft(fft(x)[1:height, 1:width], inverse = T))
   }
   if (match.arg(yaxis) == 'up') x <- x[height:1,]
 

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -19,8 +19,10 @@ txtimage <- function(
 
   if (match.arg(yaxis) == 'up') z <- z[height:1,]
 
-  indices <- (z - min(z, na.rm = TRUE))/diff(range(z, na.rm = TRUE)) # \in [0;1]
-  indices <- 1 + indices * (length(alphabet) - 1) # \in [1; length(alphabet)]
+  indices <- ceiling((z - min(z, na.rm = TRUE))/diff(range(z, na.rm = TRUE)) * length(alphabet))
+  # NB: we have rescaled to [0; length(alphabet)], but the only zeroes correspond to
+  # points exactly equal to min(z). Let's manually reassign them to the lowest alphabet character.
+  indices[indices == 0] <- 1
 
   if (na.char %in% alphabet && any(is.na(indices)))
     warning("NAs indistinguishable from values in the plot")

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -1,9 +1,35 @@
 # vi:ts=2 et:
+
+.Lanczos <- function(x, a) {
+  # sinc(x) * sinc(x/a) clamped at +/- a
+  ifelse(x == 0, 1, (abs(x) < a) * sin(pi * x) * sin(pi * x / a) / (pi^2 * x^2 / a))
+}
+
+.resample <- function(z, width, height, a) {
+  # S(x) = \sum_{i = \floor{x} - a + 1}^{\floor{x} + a} s[i] L(x - i)
+  ret <- matrix(NA, height, width)
+  for (i in 1:height) for (j in 1:width) {
+    # get coordinates of new points in terms of original image indices
+    x <- (i - 1) / (height - 1) * (nrow(z) - 1) + 1
+    y <- (j - 1) / (width - 1) * (ncol(z) - 1) + 1
+    # original image indices to sum the Lanczos kernel over
+    # (make sure to clamp values outside the image)
+    ii <- max(1, floor(x) - a + 1):min(nrow(z), floor(x) + a)
+    jj <- max(1, floor(y) - a + 1):min(ncol(z), floor(y) + a)
+    # NB: L(x,y) = L(x) * L(y)
+    ret[i,j] <- sum(
+      tcrossprod(.Lanczos(x - ii, a), .Lanczos(y - jj, a)) * z[ii, jj]
+    )
+  }
+  ret
+}
+
 txtimage <- function(
   z, width, height, yaxis = c('up', 'down'), transpose = TRUE, na.char = ' ',
-  alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  alphabet = c(0:9, letters, LETTERS), Lanczos = 3
 ) {
   stopifnot(!is.infinite(z)) # check for +/- Inf before performing any computations involving range()
+  stopifnot(Lanczos > 0, Lanczos == round(Lanczos)) # the parameter of the kernel must be nonnegative integer
 
   # alphabet could be either a multi-character string or a vector of characters
   if (length(alphabet) == 1) alphabet <- strsplit(alphabet, NULL)[[1]]
@@ -13,9 +39,8 @@ txtimage <- function(
   if (missing(width)) width <- min(getOption('width'), ncol(z))
   if (missing(height)) height <- min(getOption('width') * 25 / 80, nrow(z))
 
-  if (width != ncol(z) || height != nrow(z)) { # must resample z to specified size
-    z <- Mod(fft(fft(z)[1:height, 1:width], inverse = TRUE))
-  }
+  if (width != ncol(z) || height != nrow(z)) # must resample z to specified size
+    z <- .resample(z, width, height, Lanczos)
 
   if (match.arg(yaxis) == 'up') z <- z[height:1,]
 

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -2,11 +2,13 @@
 
 .Lanczos <- function(x, a) {
   # sinc(x) * sinc(x/a) clamped at +/- a
-  ifelse(x == 0, 1, (abs(x) < a) * sin(pi * x) * sin(pi * x / a) / (pi^2 * x^2 / a))
+  ifelse(
+    x == 0, 1,
+    (abs(x) < a) * sin(pi * x) * sin(pi * x / a) / (pi^2 * x^2 / a)
+  )
 }
 
 .resample <- function(z, width, height, a) {
-  # S(x) = \sum_{i = \floor{x} - a + 1}^{\floor{x} + a} s[i] L(x - i)
   ret <- matrix(NA, height, width)
   for (i in 1:height) for (j in 1:width) {
     kernel <- tcrossprod(
@@ -16,14 +18,14 @@
       .Lanczos(j - 1 - (1:ncol(z) - 1) * (width - 1) / (ncol(z) - 1), a)
     )
     # normalise to alpha channel to avoid darkening
-    ret[i,j] <- sum(kernel * z) / sum(kernel)
+    ret[i,j] <- sum(kernel[kernel != 0] * z[kernel != 0]) / sum(kernel)
   }
   ret
 }
 
 txtimage <- function(
-  z, width, height, yaxis = c('up', 'down'), transpose = TRUE, na.char = ' ',
-  alphabet = c(0:9, letters, LETTERS), Lanczos = 3
+  z, width, height, yaxis = c('up', 'down'), transpose = TRUE,
+  na.char = ' ', alphabet = 0:9, Lanczos = 3
 ) {
   # check for +/- Inf before performing any computations involving range()
   stopifnot(!is.infinite(z))
@@ -34,16 +36,28 @@ txtimage <- function(
   if (length(alphabet) == 1) alphabet <- strsplit(alphabet, NULL)[[1]]
   stopifnot(nchar(alphabet) == 1)
 
+  yaxis <- match.arg(yaxis)
+
   if (transpose) z <- t(z)
   if (missing(width)) width <- min(getOption('width'), ncol(z))
+  stopifnot(width <= ncol(z))
   if (missing(height)) height <- min(getOption('width') * 25 / 80, nrow(z))
+  stopifnot(height <= nrow(z))
 
   if (width != ncol(z) || height != nrow(z)) # must resample z to specified size
-    z <- .resample(z, width, height, Lanczos)
+    z <- round(
+      .resample(z, width, height, Lanczos),
+      digits = ceiling(log10(length(alphabet)))
+    )
 
-  if (match.arg(yaxis) == 'up') z <- z[height:1,]
+  if (yaxis == 'up') z <- z[height:1,]
 
-  indices <- ceiling((z - min(z, na.rm = TRUE))/diff(range(z, na.rm = TRUE)) * length(alphabet))
+  zrange <- diff(range(z, na.rm = TRUE))
+  indices <- if (zrange != 0) {
+    ceiling((z - min(z, na.rm = TRUE))/zrange * length(alphabet))
+  } else { # handle z = const
+    rep(ceiling(length(alphabet) / 2), length(z))
+  }
   # NB: we have rescaled to [0; length(alphabet)], but the only zeroes correspond to
   # points exactly equal to min(z). Let's manually reassign them to the lowest alphabet character.
   indices[indices == 0] <- 1

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -1,0 +1,38 @@
+# vi:ts=2 et:
+txtimage <- function(
+  x, width, height,
+  alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  yaxis = c('up', 'down'), image.transpose = T, span = .1, ...
+) {
+  if (image.transpose) x <- t(x)
+  if (missing(width)) width <- min(getOption('width'), ncol(x))
+  if (missing(height)) height <- min(width * .25, ncol(x))
+  if (width != ncol(x) || height != nrow(x)) { # must resample x to specified size
+    df <- data.frame(
+      x = as.vector(x),
+      # i, j \in [0; 1]
+      i = as.vector(row(x) - 1)/(nrow(x) - 1),
+      j = as.vector(col(x) - 1)/(ncol(x) - 1)
+    )
+    newdf <- expand.grid(
+      i = seq(0, 1, length = height),
+      j = seq(0, 1, length = width)
+    )
+    x <- predict(loess(x ~ i * j, df, span = span, ...), newdf)
+  }
+  if (match.arg(yaxis) == 'up') x <- x[height:1,]
+
+  # alphabet could be either a multi-character string or a vector of characters
+  if (length(alphabet) == 1) alphabet <- strsplit(alphabet, NULL)[[1]]
+  stopifnot(nchar(alphabet) == 1)
+
+  indices <- (x - min(x, na.rm = T))/diff(range(x, na.rm = T)) # \in [0;1]
+  indices <- 1 + indices * (length(alphabet) - 1) # \in [1; length(alphabet)]
+  indices[!is.finite(indices)] <- NA # in case we got NaNs
+
+  txt <- structure(alphabet[indices], dim = dim(x))
+  txt[is.na(txt)] <- ' ' # space is a good substitute for NAs in this context
+
+  cat(t(cbind(txt, '\n')), sep = '')
+  invisible(txt) # in case you need it for something
+}

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -1,6 +1,6 @@
 # vi:ts=2 et:
 txtimage <- function(
-  z, width, height, yaxis = c('up', 'down'), image.transpose = T, na.char = ' ',
+  z, width, height, yaxis = c('up', 'down'), transpose = TRUE, na.char = ' ',
   alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 ) {
   stopifnot(!is.infinite(z)) # check for +/- Inf before performing any computations involving range()
@@ -9,17 +9,17 @@ txtimage <- function(
   if (length(alphabet) == 1) alphabet <- strsplit(alphabet, NULL)[[1]]
   stopifnot(nchar(alphabet) == 1)
 
-  if (image.transpose) z <- t(z)
+  if (transpose) z <- t(z)
   if (missing(width)) width <- min(getOption('width'), ncol(z))
   if (missing(height)) height <- min(getOption('width') * 25 / 80, nrow(z))
 
   if (width != ncol(z) || height != nrow(z)) { # must resample z to specified size
-    z <- Mod(fft(fft(z)[1:height, 1:width], inverse = T))
+    z <- Mod(fft(fft(z)[1:height, 1:width], inverse = TRUE))
   }
 
   if (match.arg(yaxis) == 'up') z <- z[height:1,]
 
-  indices <- (z - min(z, na.rm = T))/diff(range(z, na.rm = T)) # \in [0;1]
+  indices <- (z - min(z, na.rm = TRUE))/diff(range(z, na.rm = TRUE)) # \in [0;1]
   indices <- 1 + indices * (length(alphabet) - 1) # \in [1; length(alphabet)]
 
   if (na.char %in% alphabet && any(is.na(indices)))

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -4,49 +4,56 @@
 \title{Display a Text Image of a Matrix}
 \description{
   Print a rudimentary image of a matrix on the R console using a
-  user-supplied alphabet as a \dQuote{palette} of sorts.
+  user-supplied alphabet as a palette of sorts.
 }
 \usage{
-  txtimage(z, width, height, yaxis, image.transpose, na.char, alphabet)
+  txtimage(z, width, height, yaxis, transpose, na.char, alphabet)
 }
 \arguments{
   \item{z}{
-    numeric matrix containing values to be plotted (NAs are allowed)
+    Numeric matrix containing values to be plotted. \code{NA} and
+    \code{NaN} are allowed, but infinities cause an error.
   }
   \item{width}{
-    desired width in characters, defaults to full screen or number of
-    columns in \code{z}, whichever is less
+    Desired width in characters. Defaults to full screen (by means of
+    \code{getOption('width')}) or number of columns (rows if transposed)
+    in \code{z}, whichever is less.
   }
   \item{height}{
-    desired height in characters, defaults to 25/80 of width or number
-    of rows in \code{z}, whichever is less
+    Desired height in characters. Defaults to 25/80 of \code{width} or
+    number of rows (columns if transposed) in \code{z}, whichever is less.
   }
   \item{yaxis}{
-    direction of the Y axis, defaults to 'up' like in \code{image}
+    Direction of the Y axis, \code{"up"} or \code{"down"}. Defaults to
+    'up' like in \code{image}.
   }
-  \item{image.transpose}{
-    whether to draw rows of the matrix horizontally, like \code{image} does
+  \item{transpose}{
+    Whether to arrange rows by the X axis, like \code{image}
+    does. Defaults to \code{TRUE}.
   }
   \item{na.char}{
-    character to substitute for NAs (if any)
+    Character to substitute for values satisfying \code{is.na}. A warning
+    is produced if \code{na.char} is found in the \code{alphabet} in
+    presence of \code{NA} in \code{z}.
   }
   \item{alphabet}{
-    symbols to compose the plot of, linear scale. Either a single
+    Symbols to compose the plot of, linear scale. Either a single
     multi-character string or a vector of single-character strings.
-    NAs are separately substituted for \code{na.char}.
+    Defaults to \code{c(0:9, letters, LETTERS)}.
   }
 }
 \details{
   By default, \code{txtimage} mimics the behaviour of \code{image},
-  drawing the rows of the matrix along the x axis and making the y values
-  grow from bottom to top of the plot. The function can be made to mimic
-  matrix \code{print} instead (rows arranged vertically from top to
+  drawing the rows of the matrix along the X axis and making the Y axis
+  grow from bottom to the top of the plot. The function can be made to
+  mimic matrix \code{print} instead (rows arranged vertically from top to
   bottom) by specifying \code{yaxis} and \code{image.transpose} arguments.
 
   If requested \code{width} or \code{height} is less than dimensions
-  of the matrix, it is resampled using \code{fft} by decimating the
+  of the matrix, it is resampled using \code{fft} by discarding the
   unnecessary high frequencies in the frequency domain and performing
-  the inverse transformation.
+  the inverse transformation. Which means that, when resampling, the
+  rows and columns are assumed to correspond to a uniform linear grid.
 }
 \value{
   The function is called for its side effect of printing the textual
@@ -61,5 +68,9 @@
 }
 \examples{
   txtimage(datasets::volcano)
+  \dontrun{
+    # try this if your terminal supports shade/block characters
+    txtimage(datasets::volcano, alphabet = " \u2591\u2592\u2593\u2588")
+  }
 }
 \keyword{hplot}

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -7,12 +7,16 @@
   user-supplied alphabet as a palette of sorts.
 }
 \usage{
-  txtimage(z, width, height, yaxis, transpose, na.char, alphabet)
+  txtimage(
+    z, width, height, yaxis = c('up', 'down'), transpose = TRUE,
+    na.char = ' ', alphabet = c(0:9, letters, LETTERS), Lanczos = 3
+  )
 }
 \arguments{
   \item{z}{
     Numeric matrix containing values to be plotted. \code{NA} and
-    \code{NaN} are allowed, but infinities cause an error.
+    \code{NaN} are allowed, but infinities, being impossible to scale,
+    cause an error.
   }
   \item{width}{
     Desired width in characters. Defaults to full screen (by means of
@@ -20,8 +24,9 @@
     in \code{z}, whichever is less.
   }
   \item{height}{
-    Desired height in characters. Defaults to 25/80 of \code{width} or
-    number of rows (columns if transposed) in \code{z}, whichever is less.
+    Desired height in characters. Defaults to \eqn{25/80} of \code{width}
+    or number of rows (columns if transposed) in \code{z}, whichever
+    is less.
   }
   \item{yaxis}{
     Direction of the Y axis, \code{"up"} or \code{"down"}. Defaults to
@@ -41,6 +46,11 @@
     multi-character string or a vector of single-character strings.
     Defaults to \code{c(0:9, letters, LETTERS)}.
   }
+  \item{Lanczos}{
+    Positive integer defining the size of the Lanczos filter kernel. Given
+    a value of \eqn{a}, the windowed sinc kernel will have \eqn{2a-1}
+    lobes.
+  }
 }
 \details{
   By default, \code{txtimage} mimics the behaviour of \code{image},
@@ -49,11 +59,23 @@
   mimic matrix \code{print} instead (rows arranged vertically from top to
   bottom) by specifying \code{yaxis} and \code{image.transpose} arguments.
 
-  If requested \code{width} or \code{height} is less than dimensions
-  of the matrix, it is resampled using \code{fft} by discarding the
-  unnecessary high frequencies in the frequency domain and performing
-  the inverse transformation. Which means that, when resampling, the
-  rows and columns are assumed to correspond to a uniform linear grid.
+  If requested \code{width} or \code{height} is different from dimensions
+  of the matrix, it is resampled using the Lanczos filter:
+
+  \deqn{%
+    L(x) = \mathrm{sinc}(x) \, \mathrm{sinc}(x/a) \, | x < a |
+  }{%
+    L(x) = sinc(x) sinc(x/a) |x < a|
+  }
+  \deqn{%
+    S(x) = \sum_{i = \lfloor x \rfloor - a + 1}^{\lfloor x \rfloor + a} %
+      s_i L(x - i)
+  }{%
+    S(x) = sum(s[floor(x) + (1 - a):a] * L(x - floor(x) + (1 - a):a))
+  }
+
+  When resampling, the rows and columns are assumed to correspond to a
+  uniform linear grid.
 }
 \value{
   The function is called for its side effect of printing the textual

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -68,10 +68,9 @@
     L(x) = sinc(x) sinc(x/a) |x < a|
   }
   \deqn{%
-    S(x) = \sum_{i = \lfloor x \rfloor - a + 1}^{\lfloor x \rfloor + a} %
-      s_i L(x - i)
+    S_{ij} = \sum_{k, l} s_{kl} L \left( i - \frac{k}{r} \right) L \left(j - \frac{l}{r} \right)
   }{%
-    S(x) = sum(s[floor(x) + (1 - a):a] * L(x - floor(x) + (1 - a):a))
+    S[i, j] = sum(s[k, l] * tcrossprod(L(i - k/r), L(j - l/r)))
   }
 
   When resampling, the rows and columns are assumed to correspond to a

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -1,0 +1,46 @@
+% vi:ts=2 et:
+\name{txtimage}
+\alias{txtimage}
+\title{Display a Text Image of a Matrix}
+\description{
+%% TODO: ~~ A concise (1-5 lines) description of what the function does. ~~
+}
+\usage{
+  txtimage(x, width, height, alphabet, yaxis, image.transpose, span, ...)
+}
+\arguments{
+  \item{x}{numeric matrix containing values to be plotted (NAs are allowed)}
+  \item{width}{desired width in characters, defaults to full screen}
+  \item{height}{desired height in characters, defaults to .25 of width}
+  \item{alphabet}{
+    symbols to compose the plot of, linear scale. NAs become spaces.
+    Either a single multi-character string or a vector of single-character strings.
+  }
+  \item{yaxis}{
+    direction of the Y axis, defaults to 'up' like in \code{\link{image}}
+  }
+  \item{image.transpose}{
+    whether to draw rows of the matrix horizontally, like \code{\link{image}} does
+  }
+  \item{span}{passed to \code{\link{loess}} when resampling}
+  \item{\dots}{passed to \code{\link{loess}} when resampling}
+}
+\details{
+  %TODO: make sure to mention loess
+}
+\value{
+  The function is called for its side effect of printing the textual
+  plot on the R standard output using \code{\link{cat}}, but it also
+  invisibly returns the resulting character matrix.
+}
+\author{
+  Ivan Krylov
+}
+\seealso{
+  \code{\link{image}}, \code{\link{loess}}
+}
+\examples{
+  txtimage(datasets::volcano)
+}
+\keyword{hplot}
+\keyword{print}

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -9,53 +9,55 @@
 \usage{
   txtimage(
     z, width, height, yaxis = c('up', 'down'), transpose = TRUE,
-    na.char = ' ', alphabet = c(0:9, letters, LETTERS), Lanczos = 3
+    na.char = ' ', alphabet = 0:9, Lanczos = 3
   )
 }
 \arguments{
   \item{z}{
-    Numeric matrix containing values to be plotted. \code{NA} and
+    Numeric matrix containing values to be plotted.  \code{NA} and
     \code{NaN} are allowed, but infinities, being impossible to scale,
     cause an error.
   }
   \item{width}{
-    Desired width in characters. Defaults to full screen (by means of
+    Desired width in characters.  Defaults to full screen (by means of
     \code{getOption('width')}) or number of columns (rows if transposed)
-    in \code{z}, whichever is less.
-  }
+    in \code{z}, whichever is less.   Asking for more characters than
+    there is in the supplied matrix results in an error.
+ }
   \item{height}{
-    Desired height in characters. Defaults to \eqn{25/80} of \code{width}
+    Desired height in characters.  Defaults to \eqn{25/80} of \code{width}
     or number of rows (columns if transposed) in \code{z}, whichever
-    is less.
+    is less.  Asking for more characters than there is in the supplied
+    matrix results in an error.
   }
   \item{yaxis}{
-    Direction of the Y axis, \code{"up"} or \code{"down"}. Defaults to
+    Direction of the Y axis, \code{"up"} or \code{"down"}.  Defaults to
     'up' like in \code{image}.
   }
   \item{transpose}{
     Whether to arrange rows by the X axis, like \code{image}
-    does. Defaults to \code{TRUE}.
+    does.  Defaults to \code{TRUE}.
   }
   \item{na.char}{
-    Character to substitute for values satisfying \code{is.na}. A warning
+    Character to substitute for values satisfying \code{is.na}.  A warning
     is produced if \code{na.char} is found in the \code{alphabet} in
     presence of \code{NA} in \code{z}.
   }
   \item{alphabet}{
-    Symbols to compose the plot of, linear scale. Either a single
+    Symbols to compose the plot of, linear scale.  Either a single
     multi-character string or a vector of single-character strings.
-    Defaults to \code{c(0:9, letters, LETTERS)}.
+    Defaults to \code{0:9}.
   }
   \item{Lanczos}{
-    Positive integer defining the size of the Lanczos filter kernel. Given
-    a value of \eqn{a}, the windowed sinc kernel will have \eqn{2a-1}
-    lobes.
+    Positive integer defining the size of the Lanczos filter kernel.
+    Given a value of \eqn{a}, the windowed sinc kernel will have
+    \eqn{2a-1} lobes.
   }
 }
 \details{
   By default, \code{txtimage} mimics the behaviour of \code{image},
   drawing the rows of the matrix along the X axis and making the Y axis
-  grow from bottom to the top of the plot. The function can be made to
+  grow from bottom to the top of the plot.  The function can be made to
   mimic matrix \code{print} instead (rows arranged vertically from top to
   bottom) by specifying \code{yaxis} and \code{image.transpose} arguments.
 
@@ -63,12 +65,14 @@
   of the matrix, it is resampled using the Lanczos filter:
 
   \deqn{%
-    L(x) = \mathrm{sinc}(x) \, \mathrm{sinc}(x/a) \, | x < a |
+    L(x) = \mathrm{sinc}(x) \, \mathrm{sinc}(x/a) \, | x | < a
   }{%
-    L(x) = sinc(x) sinc(x/a) |x < a|
+    L(x) = sinc(x) sinc(x/a) |x|<a
   }
   \deqn{%
-    S_{ij} = \sum_{k, l} s_{kl} L \left( i - \frac{k}{r} \right) L \left(j - \frac{l}{r} \right)
+    S_{ij} = \sum_{k, l} s_{kl} %
+      L \left( i - \frac{k}{r} \right) %
+      L \left( j - \frac{l}{r} \right)
   }{%
     S[i, j] = sum(s[k, l] * tcrossprod(L(i - k/r), L(j - l/r)))
   }
@@ -81,11 +85,24 @@
   plot on the R console using \code{cat}, but it also invisibly
   returns the resulting character matrix.
 }
+\note{
+  Resampling constant singnals may produce rounding errors that get
+  greatly amplified after scaling them to \code{diff(range(z))}.
+  This is compensated by rounding the result of the rounding to
+  just enough significant digits to give different indices for all
+  characters in the given alphabet.  Resampling high frequency signals
+  (e.g. \code{outer(1:200, 1:200, function(x,y) cos(x*y))} might give
+  hard-to-interpret results.
+}
 \author{
   Ivan Krylov
 }
 \seealso{
   \code{image}
+}
+\references{
+  Szeliski, R. (2010) \emph{Computer Vision: Algorithms and Applications.}
+  \url{http://szeliski.org/Book/} Section 3.5.2: Decimation.
 }
 \examples{
   txtimage(datasets::volcano)

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -6,7 +6,7 @@
 %% TODO: ~~ A concise (1-5 lines) description of what the function does. ~~
 }
 \usage{
-  txtimage(x, width, height, alphabet, yaxis, image.transpose, span, ...)
+  txtimage(x, width, height, alphabet, yaxis, image.transpose)
 }
 \arguments{
   \item{x}{numeric matrix containing values to be plotted (NAs are allowed)}
@@ -22,11 +22,9 @@
   \item{image.transpose}{
     whether to draw rows of the matrix horizontally, like \code{\link{image}} does
   }
-  \item{span}{passed to \code{\link{loess}} when resampling}
-  \item{\dots}{passed to \code{\link{loess}} when resampling}
 }
 \details{
-  %TODO: make sure to mention loess
+  %TODO: make sure to mention fft
 }
 \value{
   The function is called for its side effect of printing the textual

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -1,20 +1,26 @@
 % vi:ts=2 et:
+\encoding{UTF-8}
 \name{txtimage}
 \alias{txtimage}
 \title{Display a Text Image of a Matrix}
 \description{
-%% TODO: ~~ A concise (1-5 lines) description of what the function does. ~~
+  Print a rudimentary image of a matrix on the R console using a
+  user-supplied alphabet as a \dQuote{palette} of sorts.
 }
 \usage{
-  txtimage(x, width, height, alphabet, yaxis, image.transpose)
+  txtimage(z, width, height, yaxis, image.transpose, na.char, alphabet)
 }
 \arguments{
-  \item{x}{numeric matrix containing values to be plotted (NAs are allowed)}
-  \item{width}{desired width in characters, defaults to full screen}
-  \item{height}{desired height in characters, defaults to .25 of width}
-  \item{alphabet}{
-    symbols to compose the plot of, linear scale. NAs become spaces.
-    Either a single multi-character string or a vector of single-character strings.
+  \item{z}{
+    numeric matrix containing values to be plotted (NAs are allowed)
+  }
+  \item{width}{
+    desired width in characters, defaults to full screen or number of
+    columns in \code{z}, whichever is less
+  }
+  \item{height}{
+    desired height in characters, defaults to 25/80 of width or number
+    of rows in \code{z}, whichever is less
   }
   \item{yaxis}{
     direction of the Y axis, defaults to 'up' like in \code{\link{image}}
@@ -22,23 +28,44 @@
   \item{image.transpose}{
     whether to draw rows of the matrix horizontally, like \code{\link{image}} does
   }
+  \item{na.char}{
+    character to substitute for NAs (if any)
+  }
+  \item{alphabet}{
+    symbols to compose the plot of, linear scale. Either a single
+    multi-character string or a vector of single-character strings.
+    NAs are separately substituted for \code{na.char}.
+  }
 }
 \details{
-  %TODO: make sure to mention fft
+  By default, \code{\link{txtplot}} mimics the behaviour of
+  \code{\link{image}}, drawing the rows of the matrix along the x axis
+  and making the y values grow from bottom to top of the plot. The
+  function can be made to mimic matrix \code{\link{print}} instead (rows
+  arranged vertically from top to bottom) by specifying \code{yaxis}
+  and \code{image.transpose} arguments.
+
+  If requested \code{width} or \code{height} is less than dimensions of
+  the matrix, it is resampled using \code{\link{fft}} by decimating the
+  unnecessary high frequencies in the frequency domain and performing
+  the inverse transformation.
 }
 \value{
   The function is called for its side effect of printing the textual
-  plot on the R standard output using \code{\link{cat}}, but it also
-  invisibly returns the resulting character matrix.
+  plot on the R console using \code{\link{cat}}, but it also invisibly
+  returns the resulting character matrix.
 }
 \author{
   Ivan Krylov
 }
 \seealso{
-  \code{\link{image}}, \code{\link{loess}}
+  \code{\link{image}}
 }
 \examples{
   txtimage(datasets::volcano)
+  \dontshow{ # FIXME: LaTeX vs Unicode
+    txtimage(datasets::volcano, alphabet = ' ░▒▓█')
+  }
 }
 \keyword{hplot}
 \keyword{print}

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -1,5 +1,4 @@
 % vi:ts=2 et:
-\encoding{UTF-8}
 \name{txtimage}
 \alias{txtimage}
 \title{Display a Text Image of a Matrix}
@@ -23,10 +22,10 @@
     of rows in \code{z}, whichever is less
   }
   \item{yaxis}{
-    direction of the Y axis, defaults to 'up' like in \code{\link{image}}
+    direction of the Y axis, defaults to 'up' like in \code{image}
   }
   \item{image.transpose}{
-    whether to draw rows of the matrix horizontally, like \code{\link{image}} does
+    whether to draw rows of the matrix horizontally, like \code{image} does
   }
   \item{na.char}{
     character to substitute for NAs (if any)
@@ -38,34 +37,29 @@
   }
 }
 \details{
-  By default, \code{\link{txtplot}} mimics the behaviour of
-  \code{\link{image}}, drawing the rows of the matrix along the x axis
-  and making the y values grow from bottom to top of the plot. The
-  function can be made to mimic matrix \code{\link{print}} instead (rows
-  arranged vertically from top to bottom) by specifying \code{yaxis}
-  and \code{image.transpose} arguments.
+  By default, \code{txtimage} mimics the behaviour of \code{image},
+  drawing the rows of the matrix along the x axis and making the y values
+  grow from bottom to top of the plot. The function can be made to mimic
+  matrix \code{print} instead (rows arranged vertically from top to
+  bottom) by specifying \code{yaxis} and \code{image.transpose} arguments.
 
-  If requested \code{width} or \code{height} is less than dimensions of
-  the matrix, it is resampled using \code{\link{fft}} by decimating the
+  If requested \code{width} or \code{height} is less than dimensions
+  of the matrix, it is resampled using \code{fft} by decimating the
   unnecessary high frequencies in the frequency domain and performing
   the inverse transformation.
 }
 \value{
   The function is called for its side effect of printing the textual
-  plot on the R console using \code{\link{cat}}, but it also invisibly
+  plot on the R console using \code{cat}, but it also invisibly
   returns the resulting character matrix.
 }
 \author{
   Ivan Krylov
 }
 \seealso{
-  \code{\link{image}}
+  \code{image}
 }
 \examples{
   txtimage(datasets::volcano)
-  \dontshow{ # FIXME: LaTeX vs Unicode
-    txtimage(datasets::volcano, alphabet = ' ░▒▓█')
-  }
 }
 \keyword{hplot}
-\keyword{print}

--- a/man/txtimage.Rd
+++ b/man/txtimage.Rd
@@ -98,7 +98,7 @@
   Ivan Krylov
 }
 \seealso{
-  \code{image}
+  \code{symnum}, \code{image}
 }
 \references{
   Szeliski, R. (2010) \emph{Computer Vision: Algorithms and Applications.}

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -23,3 +23,12 @@ txtplot(runif(10000,0,115000),100001:110000)
 txtplot(runif(10000,-115000,0), seq(1,9,length=10000))
 txtboxplot(runif(10000,0,115000))
 txtboxplot(runif(10000,-115000.0))
+
+z <- datasets::volcano
+txtimage(z, alphabet = 0:9)
+txtimage(z, 20, 10, yaxis = 'd', transpose = FALSE, alphabet = ' .:-+=#')
+z[10,10] <- +Inf
+stopifnot(inherits(try(txtimage(z), TRUE), 'try-error'))
+#z[10,10] <- NA # FIXME: fails because of fft resampling
+#z[11,11] <- NaN
+#txtimage(z, na.char = '?')

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -25,10 +25,11 @@ txtboxplot(runif(10000,0,115000))
 txtboxplot(runif(10000,-115000.0))
 
 z <- datasets::volcano
-txtimage(z, alphabet = 0:9)
+txtimage(z, alphabet = c(0:9, letters, LETTERS))
 txtimage(z, 20, 10, yaxis = 'd', transpose = FALSE, alphabet = ' .:-+=#')
 z[10,10] <- +Inf
 stopifnot(inherits(try(txtimage(z), TRUE), 'try-error'))
-z[10,10] <- NA # FIXME: fails because of fft resampling
+z[10,10] <- NA
 z[11,11] <- NaN
-txtimage(z, na.char = '?')
+txtimage(z, na.char = '?', Lanczos = 1)
+txtimage(matrix(10, 200, 200))

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -29,6 +29,6 @@ txtimage(z, alphabet = 0:9)
 txtimage(z, 20, 10, yaxis = 'd', transpose = FALSE, alphabet = ' .:-+=#')
 z[10,10] <- +Inf
 stopifnot(inherits(try(txtimage(z), TRUE), 'try-error'))
-#z[10,10] <- NA # FIXME: fails because of fft resampling
-#z[11,11] <- NaN
-#txtimage(z, na.char = '?')
+z[10,10] <- NA # FIXME: fails because of fft resampling
+z[11,11] <- NaN
+txtimage(z, na.char = '?')


### PR DESCRIPTION
Hi Björn!

Here is the `txtimage` function I had e-mailed you about. I ended up spending way too much time on it, but the resulting algorithm should correctly downsample big high-frequency images while still being faster than `loess`. Feel free to change the default width or height of the image or poke me to try to make `.resample` faster by only computing the kernel for points where it is non-zero.

I also ended up producing many commits. I can squash them for you if you want.

Best regards,
Ivan