### PR TITLE
`.resample`: faster convolution by sparse matrices

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Description: Provides functions to produce rudimentary ascii graphics
         directly in the terminal window. Provides a basic plotting
         function (and equivalents of curve, density, acf and barplot)
         as well as boxplot and image functions.
+Imports: Matrix
 License: LGPL
 LazyLoad: yes
 Packaged: 2012-07-24 23:11:16 UTC; bjoern

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,3 @@
 importFrom("grDevices", "boxplot.stats")
 importFrom("stats", "acf", "density", "na.fail")
-importFrom("Matrix", "Matrix", "colSums")
 export(txtplot, txtdensity, txtcurve, txtacf, txtbarchart, txtboxplot, txtimage)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
 importFrom("grDevices", "boxplot.stats")
 importFrom("stats", "acf", "density", "na.fail")
+importFrom("Matrix", "Matrix", "colSums")
 export(txtplot, txtdensity, txtcurve, txtacf, txtbarchart, txtboxplot, txtimage)

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -9,17 +9,25 @@
 }
 
 .resample <- function(z, width, height, a) {
-  ret <- matrix(NA, height, width)
-  for (i in 1:height) for (j in 1:width) {
-    kernel <- tcrossprod(
-      # L(x,y) = L(x) * L(y)
-      # the Lanczos kernel argument is in terms of new coordinates
-      .Lanczos(i - 1 - (1:nrow(z) - 1) * (height - 1) / (nrow(z) - 1), a),
-      .Lanczos(j - 1 - (1:ncol(z) - 1) * (width - 1) / (ncol(z) - 1), a)
-    )
-    # normalise to alpha channel to avoid darkening
-    ret[i,j] <- sum(kernel[kernel != 0] * z[kernel != 0]) / sum(kernel)
-  }
+  # L(x,y) = L(x) * L(y) for every combination of pixels
+  kernels <- Matrix(vapply(
+    seq(1, width),
+    # the Lanczos kernel argument is in terms of new coordinates
+    function(j) .Lanczos(j - 1 - (seq(1, ncol(z)) - 1) * (width - 1) / (ncol(z) - 1), a),
+    numeric(ncol(z))
+  ), sparse = TRUE) %x% Matrix(vapply(
+    seq(1, height),
+    function(i) .Lanczos(i - 1 - (seq(1, nrow(z)) - 1) * (height - 1) / (nrow(z) - 1), a),
+    numeric(nrow(z))
+  ), sparse = TRUE)
+  ret <- matrix(
+    replace(as.vector(z), is.na(z), 0) %*% kernels /
+      # normalise to alpha channel to avoid darkening
+      colSums(kernels),
+    height, width
+  )
+  # anything touched by a missing pixel with a nonzero weight must be missing
+  is.na(ret) <- as.vector(0 < as.vector(is.na(z)) %*% (kernels != 0))
   ret
 }
 

--- a/R/txtimage.R
+++ b/R/txtimage.R
@@ -10,12 +10,12 @@
 
 .resample <- function(z, width, height, a) {
   # L(x,y) = L(x) * L(y) for every combination of pixels
-  kernels <- Matrix(vapply(
+  kernels <- Matrix::Matrix(vapply(
     seq(1, width),
     # the Lanczos kernel argument is in terms of new coordinates
     function(j) .Lanczos(j - 1 - (seq(1, ncol(z)) - 1) * (width - 1) / (ncol(z) - 1), a),
     numeric(ncol(z))
-  ), sparse = TRUE) %x% Matrix(vapply(
+  ), sparse = TRUE) %x% Matrix::Matrix(vapply(
     seq(1, height),
     function(i) .Lanczos(i - 1 - (seq(1, nrow(z)) - 1) * (height - 1) / (nrow(z) - 1), a),
     numeric(nrow(z))
@@ -23,7 +23,7 @@
   ret <- matrix(
     replace(as.vector(z), is.na(z), 0) %*% kernels /
       # normalise to alpha channel to avoid darkening
-      colSums(kernels),
+      Matrix::colSums(kernels),
     height, width
   )
   # anything touched by a missing pixel with a nonzero weight must be missing


### PR DESCRIPTION
The nested for-loop I had suggested back in 2020 is very slow:

```r
library(txtplot)
N <- 20
system.time(for (i in 1:N) txtimage(matrix(10, 200, 200))) / N
# current version:
#    user  system elapsed
# 0.58680 0.00605 0.59285
```

We can speed it up at the cost of introducing a dependency on the recommended package [Matrix](https://cran.r-project.org/package=Matrix), which is admittedly slow to load by itself:

```r
system.time(library(txtplot))
# new version:
#    user  system elapsed
#   0.644   0.039   0.684
N <- 20
system.time(for (i in 1:N) txtimage(matrix(10, 200, 200))) / N
#    user  system elapsed
# 0.05915 0.01305 0.07220
```

What used to be a nested for loop (for every row `i`, every column `j`, compute the Lanczos kernels, sum the elementwise product, normalise) can be sped up by using more matrix operations:

1. Compute per-row and per-column Lanczos kernels, store them in sparse matrices
2. Use a Kronecker product to obtain a giant $O(\mathtt{length}(\mathtt{z})\cdot{}\mathtt{width}\cdot{}\mathtt{height})$ but sparse matrix containing every kernel needed to compute the resampled matrix
3. Use a matrix product to resample the matrix in one operation
4. Propagate the missingness from the source matrix

What do you think? I really appreciate packages that have no non-base dependencies, and while Matrix has `Priority: recommended` and should therefore be installed almost everywhere where R is, the dependency count would no longer be zero. If you have other ideas regarding signal-conservative image resizing in base R, please let me know.

I can also delay loading `Matrix` by using calls of the form `Matrix::Matrix` instead of `importFrom(Matrix, ...)` in the `NAMESPACE`. This would help `txtplot` load as fast as it currently does, but the first call to `txtimage(...)` would be delayed by half a second.